### PR TITLE
fix for charlist response

### DIFF
--- a/lib/plug/accesslog/formatter.ex
+++ b/lib/plug/accesslog/formatter.ex
@@ -65,7 +65,7 @@ defmodule Plug.AccessLog.Formatter do
   defp format(<< "%b", rest :: binary >>, conn, message) do
     content_length = case get_resp_header(conn, "Content-Length") do
       [ length ] -> length
-      _          -> (conn.resp_body || "") |> byte_size()
+      _          -> (conn.resp_body || "") |> to_string() |> byte_size()
     end
 
     if 0 == content_length do

--- a/lib/plug/accesslog/logfiles.ex
+++ b/lib/plug/accesslog/logfiles.ex
@@ -16,7 +16,16 @@ defmodule Plug.AccessLog.Logfiles do
   def get(logfile) do
     case get_device(logfile) do
       nil    -> open(logfile)
-      device -> device
+      device when is_pid(device) ->
+        case :erlang.is_process_alive(device) do
+          true  -> device
+          false ->
+            case File.open(logfile, [ :append, :utf8 ]) do
+              { :error, _ }   -> nil
+              { :ok, device } -> replace(logfile, device)
+            end
+        end
+      other_device -> other_device
     end
   end
 

--- a/test/plug/accesslog/logfiles_test.exs
+++ b/test/plug/accesslog/logfiles_test.exs
@@ -38,4 +38,16 @@ defmodule Plug.AccessLog.LogfilesTest do
     refute log_device == Logfiles.get(logfile)
     assert new_device == Logfiles.get(logfile)
   end
+
+  test "logfile device automatically restored in case of crash" do
+    logfile =
+         [ __DIR__, "../../logs/plug_accesslog_logfiles_restore.log" ]
+      |> Path.join()
+      |> Path.expand()
+    old_pid = logfile |> Logfiles.get()
+    :erlang.exit(old_pid, :kill)
+    new_pid = logfile |> Logfiles.get()
+    assert is_pid(new_pid)
+    refute old_pid == new_pid
+  end
 end

--- a/test/plug/accesslog_test.exs
+++ b/test/plug/accesslog_test.exs
@@ -54,6 +54,7 @@ defmodule Plug.AccessLogTest do
     plug :dispatch
 
     get "/", do: send_resp(conn, 200, "OK")
+    get "/charlist", do: send_resp(conn, 200, 'OK')
   end
 
   @opts     Router.init([])
@@ -62,17 +63,19 @@ defmodule Plug.AccessLogTest do
 
 
   setup_all do
-    conn(:get, "/")
-    |> put_req_header("Referer", @test_ref)
-    |> put_req_header("User-Agent", @test_ua)
-    |> Router.call(@opts)
+    Enum.each ["/", "/charlist"], fn(path) ->
+      conn(:get, path)
+      |> put_req_header("Referer", @test_ref)
+      |> put_req_header("User-Agent", @test_ua)
+      |> Router.call(@opts)
+    end
 
     :ok
   end
 
 
   test ":agent format" do
-    assert @test_ua == Logfiles.logfile_agent |> File.read!() |> String.strip()
+    assert @test_ua == Logfiles.logfile_agent |> File.read!() |> String.split("\n") |> List.first
   end
 
   test ":clf format" do
@@ -104,7 +107,7 @@ defmodule Plug.AccessLogTest do
   end
 
   test ":referer format" do
-    log = Logfiles.logfile_referer |> File.read!() |> String.strip()
+    log = Logfiles.logfile_referer |> File.read!() |> String.split("\n") |> List.first
     res = "#{ @test_ref } -> /"
 
     assert res == log


### PR DESCRIPTION
When using `Phoenix.Controller.json/2` method it sends charlist as response which leads to error in `conn.resp_body |> byte_size()` call in `Plug.AccessLog.Formatter.format/3` on line 68. This patch adds explicit cast to string of the response body before checking its byte size.
